### PR TITLE
Removed YAJL dependency

### DIFF
--- a/faye-redis-delayed.gemspec
+++ b/faye-redis-delayed.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faye'
   spec.add_dependency 'faye-redis', '>= 0.2.0'
 
+  spec.add_dependency 'multi_json', '~> 1.0'
+
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/lib/faye/redis_delayed.rb
+++ b/lib/faye/redis_delayed.rb
@@ -13,7 +13,7 @@ module Faye
       # fetch awaiting messages from redis and publish them
       @redis.lpop(@ns + "/channels#{channel}/awaiting_messages") do |json_message|
         if json_message
-          message = Yajl::Parser.parse(json_message)
+          message = MultiJson.load(json_message)
           publish(message, [message["channel"]], json_message)
           publish_awaiting_messages(channel)
         end


### PR DESCRIPTION
Changed the Yajl::Parser.parse call to MultiJson.load.  MultiJson
is used elsewhere, so it seems to make sense to use MultiJson
everywhere.

I also added multi_json to the gemspec as a dependency.
