### PR TITLE
Added :delay_channels list to configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ run server
 Additional options provided by `Faye::DelayedRedis`:
 
 * `:expire` — expire time in seconds, defaults to `60`
+* `:delay_channels` - Array of channels that should be delayed
+
+:delay_channels can be specified as strings or as regular expressions.
+If something is given, then only channels matching one of the listed
+patterns will be delayed.  Without this argument, every channel is
+delayed.
+
+```rb
+  :engine  => {
+    :type           => Faye::RedisDelayed,
+    :delay_channels => [/^\/queues_with_this_prefix/, "/this/one/queue"],
+  }
+```
 
 See the full list of [`Faye::Redis` engine options](https://github.com/faye/faye-redis-ruby).
 

--- a/lib/faye/.#redis_delayed.rb
+++ b/lib/faye/.#redis_delayed.rb
@@ -1,0 +1,1 @@
+mm5830@pubdevx-tmbl501.bnaint.com.4359:1428488680

--- a/lib/faye/.#redis_delayed.rb
+++ b/lib/faye/.#redis_delayed.rb
@@ -1,1 +1,0 @@
-mm5830@pubdevx-tmbl501.bnaint.com.4359:1428488680

--- a/lib/faye/redis_delayed.rb
+++ b/lib/faye/redis_delayed.rb
@@ -29,25 +29,24 @@ module Faye
       keys         = channels.map { |c| @ns + "/channels#{c}" }
 
       @redis.sunion(*keys) do |clients|
-        if clients.empty?
-          if delay_channel? message["channel"]
-            key = @ns + "/channels#{message["channel"]}/awaiting_messages"
-            # store message in redis
-            @redis.rpush(key, json_message)
-            # Set expiration time to one minute
-            @redis.expire(key, @options[:expire] || DEFAULT_EXPIRE)
-          end
-        else
-          clients.each do |client_id|
-            queue = @ns + "/clients/#{client_id}/messages"
+        if clients.empty? && delay_channel?(message["channel"])
+          key = @ns + "/channels#{message["channel"]}/awaiting_messages"
+          # store message in redis
+          @redis.rpush(key, json_message)
+          # Set expiration time to one minute
+          @redis.expire(key, @options[:expire] || DEFAULT_EXPIRE)
+        end
 
-            @server.debug 'Queueing for client ?: ?', client_id, message
-            @redis.rpush(queue, json_message)
-            @redis.publish(@message_channel, client_id)
 
-            client_exists(client_id) do |exists|
-              @redis.del(queue) unless exists
-            end
+        clients.each do |client_id|
+          queue = @ns + "/clients/#{client_id}/messages"
+
+          @server.debug 'Queueing for client ?: ?', client_id, message
+          @redis.rpush(queue, json_message)
+          @redis.publish(@message_channel, client_id)
+
+          client_exists(client_id) do |exists|
+            @redis.del(queue) unless exists
           end
         end
       end
@@ -58,28 +57,14 @@ module Faye
     private
 
     def delay_channels
-      @delay_channels ||= if @options[:delay_channels]
-                            [@options[:delay_channels]].flatten
-                          else
-                            []
-                          end
+      @delay_channels ||= Array(@options[:delay_channels]).flatten
     end
 
     # returns true if this channel should be delayed.  The default is
     # yes, unless :delay_channels is set in the engine options
 
     def delay_channel?(channel)
-      if delay_channels.empty?
-        return true
-      else
-        delay_channels.each do |pattern|
-          if pattern === channel
-            return true
-          end
-        end
-
-        return false
-      end
+      delay_channels.empty? || delay_channels.any? { |pattern| pattern === channel }
     end
   end
 end

--- a/lib/faye/redis_delayed.rb
+++ b/lib/faye/redis_delayed.rb
@@ -30,11 +30,13 @@ module Faye
 
       @redis.sunion(*keys) do |clients|
         if clients.empty?
-          key = @ns + "/channels#{message["channel"]}/awaiting_messages"
-          # store message in redis
-          @redis.rpush(key, json_message)
-          # Set expiration time to one minute
-          @redis.expire(key, @options[:expire] || DEFAULT_EXPIRE)
+          if delay_channel? message["channel"]
+            key = @ns + "/channels#{message["channel"]}/awaiting_messages"
+            # store message in redis
+            @redis.rpush(key, json_message)
+            # Set expiration time to one minute
+            @redis.expire(key, @options[:expire] || DEFAULT_EXPIRE)
+          end
         else
           clients.each do |client_id|
             queue = @ns + "/clients/#{client_id}/messages"
@@ -51,6 +53,33 @@ module Faye
       end
 
       @server.trigger(:publish, message['clientId'], message['channel'], message['data'])
+    end
+
+    private
+
+    def delay_channels
+      @delay_channels ||= if @options[:delay_channels]
+                            [@options[:delay_channels]].flatten
+                          else
+                            []
+                          end
+    end
+
+    # returns true if this channel should be delayed.  The default is
+    # yes, unless :delay_channels is set in the engine options
+
+    def delay_channel?(channel)
+      if delay_channels.empty?
+        return true
+      else
+        delay_channels.each do |pattern|
+          if pattern === channel
+            return true
+          end
+        end
+
+        return false
+      end
     end
   end
 end

--- a/lib/faye/redis_delayed.rb
+++ b/lib/faye/redis_delayed.rb
@@ -37,7 +37,6 @@ module Faye
           @redis.expire(key, @options[:expire] || DEFAULT_EXPIRE)
         end
 
-
         clients.each do |client_id|
           queue = @ns + "/clients/#{client_id}/messages"
 
@@ -59,9 +58,6 @@ module Faye
     def delay_channels
       @delay_channels ||= Array(@options[:delay_channels]).flatten
     end
-
-    # returns true if this channel should be delayed.  The default is
-    # yes, unless :delay_channels is set in the engine options
 
     def delay_channel?(channel)
       delay_channels.empty? || delay_channels.any? { |pattern| pattern === channel }


### PR DESCRIPTION
delay_channels lets you set a list of channels that should
be delayed.  If this is given, then only channels that
match the option will be stored in Redis.  Other channels
will be sent through Faye immediately without queueing
in Redis waiting for a client.

This is useful if you are using the same Faye instance
for both delayed messages and a general Faye message
queue.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/monterail/faye-redis-delayed/3)

<!-- Reviewable:end -->
